### PR TITLE
Fix RBAC

### DIFF
--- a/helm/helm-2to3-migration/templates/rbac.yaml
+++ b/helm/helm-2to3-migration/templates/rbac.yaml
@@ -52,7 +52,6 @@ subjects:
     name: {{ .Values.name }}
     namespace: {{ .Values.namespace }}
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ .Values.name }}
-  namespace: {{ .Values.namespace }}
-  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
While testing https://github.com/giantswarm/chart-operator/pull/385, 

I found a problem in the chart-operator as below. 

```
unable to build kubernetes objects from release manifest: error validating \"\": error validating data: ValidationError(ClusterRoleBinding.roleRef): unknown field \"namespace\" in io.k8s.api.rbac.v1beta1.RoleRef","kind":"unknown
```

I copy this RBAC template from cert-manager-app, not sure how that manages to avoid this problem. 