### PR TITLE
retain helm v2 releases

### DIFF
--- a/helm/helm-2to3-migration/templates/job.yaml
+++ b/helm/helm-2to3-migration/templates/job.yaml
@@ -19,7 +19,7 @@ spec:
           image: "{{ .Values.global.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
           command: ["/bin/sh" , "-c"]
           args:
-            - for r in $(cat /data/config/releases | tr "," "\n"); do 2to3 convert --delete-v2-releases --tiller-ns {{ .Values.tiller.namespace }} "$r"; if [ $? -ne 0 ]; then i=$((i+1)); fi done; if [ $i -gt 0 ]; then echo "Failed $i times"; exit 127; fi
+            - for r in $(cat /data/config/releases | tr "," "\n"); do 2to3 convert --tiller-ns {{ .Values.tiller.namespace }} "$r"; if [ $? -ne 0 ]; then i=$((i+1)); fi done; if [ $i -gt 0 ]; then echo "Failed $i times"; exit 127; fi
           volumeMounts:
             - name: config-volume
               mountPath: /data/config


### PR DESCRIPTION
Retaining helm v2 releases when we are doing migration. we will keep it as backup after then. 