### PR TITLE
Replace owner labels for backing up helm v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,9 @@ RUN wget https://github.com/helm/helm-2to3/releases/download/v0.5.0/helm-2to3_0.
 RUN tar xvzf helm-2to3_0.5.0_linux_amd64.tar.gz
 RUN cp ./2to3 /usr/local/bin
 
+# install kubectl
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
+RUN chmod +x ./kubectl
+RUN cp ./kubectl /usr/local/bin
+
 ENTRYPOINT ["2to3"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN tar xvzf helm-2to3_0.5.0_linux_amd64.tar.gz
 RUN cp ./2to3 /usr/local/bin
 
 # install kubectl
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
+RUN wget https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
 RUN chmod +x ./kubectl
 RUN cp ./kubectl /usr/local/bin
 

--- a/helm/helm-2to3-migration/templates/cm.yaml
+++ b/helm/helm-2to3-migration/templates/cm.yaml
@@ -24,8 +24,11 @@ data:
     i=0
     for r in $(cat /data/config/releases | tr "," "\n");
     do
-      if ! 2to3 convert --tiller-ns {{ .Values.tiller.namespace }} "$r"; then
+      if ! 2to3 convert --tiller-ns {{ .Values.tiller.namespace }} "$r";
+      then
          i=$((i+1));
+      else
+         kubectl -n {{ .Values.tiller.namespace }} patch cm '[{ "op": "replace", "path": "/metadata/labels/OWNER" value: "BACKUP-HELM-2" }]' --type=json
       fi
     done;
 

--- a/helm/helm-2to3-migration/templates/cm.yaml
+++ b/helm/helm-2to3-migration/templates/cm.yaml
@@ -28,7 +28,7 @@ data:
       then
          i=$((i+1));
       else
-         kubectl -n {{ .Values.tiller.namespace }} patch cm '[{ "op": "replace", "path": "/metadata/labels/OWNER" value: "BACKUP-HELM-2" }]' --type=json
+         kubectl -n {{ .Values.tiller.namespace }} get cm -lNAME=$r -o yaml | sed 's/\(OWNER: TILLER\)/OWNER: HELM-BACKUP-V2/' | kubectl replace -f -
       fi
     done;
 

--- a/helm/helm-2to3-migration/templates/rbac.yaml
+++ b/helm/helm-2to3-migration/templates/rbac.yaml
@@ -20,9 +20,11 @@ rules:
       - configmaps
       - secrets
     verbs:
+      - "get"
       - "list"
       - "create"
       - "delete"
+      - "update"
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
We are replacing `OWNER` label in release configmap to not sync them with tiller pod until we ensure we are not going back to helm 2. 