### PR TITLE
Update API groups in clusterrole

### DIFF
--- a/helm/helm-2to3-migration/templates/rbac.yaml
+++ b/helm/helm-2to3-migration/templates/rbac.yaml
@@ -12,34 +12,34 @@ rules:
     resources:
       - pods
     verbs:
-      - "get"
-      - "list"
+      - get
+      - list
   - apiGroups:
       - ""
     resources:
       - configmaps
       - secrets
     verbs:
-      - "get"
-      - "list"
-      - "create"
-      - "delete"
-      - "update"
+      - get
+      - list
+      - create
+      - delete
+      - update
   - apiGroups:
-      - ""
+      - batch
     resources:
       - jobs
     verbs:
-      - "create"
-      - "delete"
+      - create
+      - delete
   - apiGroups:
-      - extensions
+      - policy
     resources:
       - podsecuritypolicies
     resourceNames:
       - {{ .Values.name }}
     verbs:
-      - "use"
+      - use
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding


### PR DESCRIPTION
I fixed this manually in ghost but the API groups need to match the templates.

Otherwise app-operator can't create install the chart with helm 3.

```
helm3 status helm-2to3-migration -n kube-system -o yaml

info:
  deleted: ""
  description: |-
    Release "helm-2to3-migration" failed: clusterroles.rbac.authorization.k8s.io "helm-2to3-migration" is forbidden: user "system:serviceaccount:giantswarm:app-operator-unique" (groups=["system:serviceaccounts" "system:serviceaccounts:giantswarm" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
    {APIGroups:[""], Resources:["jobs"], Verbs:["create" "delete"]}
    {APIGroups:["extensions"], Resources:["podsecuritypolicies"], ResourceNames:["helm-2to3-migration"], Verbs:["use"]}
```