### PR TITLE
Use image.registry not global

### DIFF
--- a/helm/helm-2to3-migration/templates/job.yaml
+++ b/helm/helm-2to3-migration/templates/job.yaml
@@ -16,7 +16,7 @@ spec:
         runAsGroup: {{ .Values.groupID }}
       containers:
         - name: {{ .Values.name }}
-          image: "{{ .Values.global.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
           command: ["/scripts/run.sh"]
           volumeMounts:
             - name: config-volume

--- a/helm/helm-2to3-migration/values.yaml
+++ b/helm/helm-2to3-migration/values.yaml
@@ -8,10 +8,6 @@ namespace: giantswarm
 userID: 1000
 groupID: 1000
 
-global:
-  image:
-    registry: quay.io
-
 image:
   registry: quay.io
   name: giantswarm/helm-2to3-migration


### PR DESCRIPTION
In the releasemigration resource I'm going to set the image registry for China. I think we can remove the global since the chart is created directly not as a subchart.