### PR TITLE
Fix image name templating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix image name templating.
+
 ### [1.1.2] - 2020-05-13
 
 ### Changed

--- a/helm/helm-2to3-migration/values.yaml
+++ b/helm/helm-2to3-migration/values.yaml
@@ -9,8 +9,8 @@ userID: 1000
 groupID: 1000
 
 image:
-  registry: quay.io
-  name: giantswarm/helm-2to3-migration
+  registry: "quay.io"
+  name: "giantswarm/helm-2to3-migration"
   tag: [[ .Version ]]
 
 tiller:


### PR DESCRIPTION
The migration job isn't starting because the image name isn't quoted.

```
    spec:
      containers:
      - command:
        - /scripts/run.sh
        image: 'quay.io/:'
```
