### PR TITLE
Using different struct for image/tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,8 +43,6 @@ workflows:
             - build
           # Needed to trigger job only on git tag.
           filters:
-            branches:
-              only: master
             tags:
               only: /^v.*/
 

--- a/helm/helm-2to3-migration/templates/job.yaml
+++ b/helm/helm-2to3-migration/templates/job.yaml
@@ -16,7 +16,7 @@ spec:
         runAsGroup: {{ .Values.groupID }}
       containers:
         - name: {{ .Values.name }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image_name }}:{{ .Values.image_tag }}"
           command: ["/scripts/run.sh"]
           volumeMounts:
             - name: config-volume

--- a/helm/helm-2to3-migration/values.yaml
+++ b/helm/helm-2to3-migration/values.yaml
@@ -10,8 +10,9 @@ groupID: 1000
 
 image:
   registry: "quay.io"
-  name: "giantswarm/helm-2to3-migration"
-  tag: [[ .Version ]]
+
+image_name: "giantswarm/helm-2to3-migration"
+image_tag: [[ .Version ]]
 
 tiller:
   namespace: "kube-system"


### PR DESCRIPTION
In `giraffe`, we have a nasty template problems, which left the image and tag as blank. 

```
# Source: helm-2to3-migration/templates/job.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: helm-2to3-migration
  namespace: giantswarm
  labels:
    app: helm-2to3-migration
    giantswarm.io/service-type: "managed"
spec:
  ttlSecondsAfterFinished: 30
  template:
    spec:
      serviceAccountName: helm-2to3-migration
      securityContext:
        runAsUser: 1000
        runAsGroup: 1000
      containers:
        - name: helm-2to3-migration
          image: "registry-intl.cn-shanghai.aliyuncs.com/:"
          command: ["/scripts/run.sh"]
```
To mitigate this problem, we are suggesting following values changes. 