### PR TITLE
Upgarde 2to3 to 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use 0.5.1 version from 2to3 upstream.
+
 ### [1.1.3] - 2020-05-18
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM alpine:3.11
 
+ENV HELM_2TO3_VERSION 0.5.1
+
 # install 2to3
-RUN wget https://github.com/helm/helm-2to3/releases/download/v0.5.0/helm-2to3_0.5.0_linux_amd64.tar.gz
-RUN tar xvzf helm-2to3_0.5.0_linux_amd64.tar.gz
+RUN wget https://github.com/helm/helm-2to3/releases/download/v${HELM_2TO3_VERSION}/helm-2to3_${HELM_2TO3_VERSION}_linux_amd64.tar.gz
+RUN tar xvzf helm-2to3_${HELM_2TO3_VERSION}_linux_amd64.tar.gz
 RUN cp ./2to3 /usr/local/bin
 
 # install kubectl


### PR DESCRIPTION
There is a new release with `2to3` 0.5.1, which has a patch with hooks. 

https://github.com/helm/helm-2to3/releases/tag/v0.5.1